### PR TITLE
If args.format is defined, don't require file suffix

### DIFF
--- a/src/svviz/commandline.py
+++ b/src/svviz/commandline.py
@@ -213,7 +213,7 @@ def parseArgs(args):
     
     if args.export is not None:
         args.no_web = True
-        if args.type!="batch" and not args.export.lower()[-3:] in ["svg", "png", "pdf"]:
+        if args.type!="batch" and args.format is None and not args.export.lower()[-3:] in ["svg", "png", "pdf"]:
             print "Export filename must end with one of .svg, .png or .pdf"
             sys.exit(1)
 


### PR DESCRIPTION
Just a small thing that I noticed - if the format is defined, the --export argument is interpreted as a directory and a default file name is used.  So, there is no need for the argument to have a file type suffix
p.s. I don't really know python, so please doublecheck syntax!
